### PR TITLE
Add MongoDB and JWT authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ This repository provides a minimal Flask application for generating test data vi
 
 ## Features
 
-- **Register/Login/Logout**: Basic account management backed by SQLite.
+- **Register/Login/Logout**: Account management stored in MongoDB.
 - **Secret Keys**: Users can create multiple API keys used for authentication.
+- **JWT Sessions**: Login responses include a JWT that must be sent in the `Authorization` header.
 - **Wallet**: Deposits update a user's wallet balance. Charges are applied when generating data.
 - **OpenAI Proxy**: Requests to OpenAI are forwarded and usage is recorded. Costs are multiplied by a configurable factor.
 - **Usage Tracking**: Each request stores token usage and cost so users can review their spending.
@@ -57,5 +58,8 @@ python testdatagen/app.py
 ```
 
 3. The API will be available at `http://localhost:5000`.
+   The application expects a running MongoDB instance. Configure the connection
+   by setting the `MONGO_URI` environment variable. You can also override the
+   JWT signing key with `JWT_SECRET`.
 
 See `testdatagen/app.py` for endpoint details.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 flask
-flask_sqlalchemy
 werkzeug
 openai
 stripe
+pymongo
+PyJWT

--- a/testdatagen/app.py
+++ b/testdatagen/app.py
@@ -1,40 +1,46 @@
 from flask import Flask, request, jsonify
-from flask_sqlalchemy import SQLAlchemy
 from werkzeug.security import generate_password_hash, check_password_hash
+from functools import wraps
+from pymongo import MongoClient
+from bson.objectid import ObjectId
+import jwt
+import datetime
 import secrets
 import openai
 import stripe
+import os
 
 app = Flask(__name__)
-app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///testdatagen.db'
-app.config['SECRET_KEY'] = 'change-me'
+app.config['MONGO_URI'] = os.environ.get('MONGO_URI', 'mongodb://localhost:27017/testdatagen')
+app.config['SECRET_KEY'] = os.environ.get('JWT_SECRET', 'change-me')
 app.config['OPENAI_PRICE_MULTIPLIER'] = 3
 app.config['OPENAI_API_KEY'] = 'YOUR_OPENAI_KEY'
 app.config['STRIPE_SECRET_KEY'] = 'YOUR_STRIPE_SECRET_KEY'
 stripe.api_key = app.config['STRIPE_SECRET_KEY']
 
-db = SQLAlchemy(app)
+mongo_client = MongoClient(app.config['MONGO_URI'])
+mongo_db = mongo_client.get_default_database()
 
-class User(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
-    username = db.Column(db.String(80), unique=True, nullable=False)
-    password_hash = db.Column(db.String(128), nullable=False)
-    wallet = db.Column(db.Float, default=0.0)
 
-class SecretKey(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
-    key = db.Column(db.String(64), unique=True, nullable=False)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
-
-class Usage(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
-    prompt_tokens = db.Column(db.Integer)
-    completion_tokens = db.Column(db.Integer)
-    cost = db.Column(db.Float)
+def login_required(f):
+    """Decorator to ensure the request has a valid JWT token."""
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        token = request.headers.get('Authorization')
+        if not token:
+            return jsonify({'error': 'missing token'}), 401
+        try:
+            data = jwt.decode(token, app.config['SECRET_KEY'], algorithms=['HS256'])
+            request.user_id = data['user_id']
+        except jwt.ExpiredSignatureError:
+            return jsonify({'error': 'token expired'}), 401
+        except jwt.InvalidTokenError:
+            return jsonify({'error': 'invalid token'}), 401
+        return f(*args, **kwargs)
+    return decorated
 
 def create_app():
-    db.create_all()
+    mongo_db.users.create_index('username', unique=True)
     return app
 
 @app.route('/register', methods=['POST'])
@@ -44,11 +50,14 @@ def register():
     password = data.get('password')
     if not username or not password:
         return jsonify({'error': 'missing parameters'}), 400
-    if User.query.filter_by(username=username).first():
+    if mongo_db.users.find_one({'username': username}):
         return jsonify({'error': 'user exists'}), 400
-    user = User(username=username, password_hash=generate_password_hash(password))
-    db.session.add(user)
-    db.session.commit()
+    user = {
+        'username': username,
+        'password_hash': generate_password_hash(password),
+        'wallet': 0.0
+    }
+    mongo_db.users.insert_one(user)
     return jsonify({'message': 'registered'})
 
 @app.route('/login', methods=['POST'])
@@ -56,64 +65,52 @@ def login():
     data = request.json
     username = data.get('username')
     password = data.get('password')
-    user = User.query.filter_by(username=username).first()
-    if not user or not check_password_hash(user.password_hash, password):
+    user = mongo_db.users.find_one({'username': username})
+    if not user or not check_password_hash(user['password_hash'], password):
         return jsonify({'error': 'invalid credentials'}), 401
-    token = secrets.token_hex(16)
-    SecretKey.query.filter_by(user_id=user.id).delete()
-    secret = SecretKey(key=token, user_id=user.id)
-    db.session.add(secret)
-    db.session.commit()
+    token = jwt.encode(
+        {
+            'user_id': str(user['_id']),
+            'exp': datetime.datetime.utcnow() + datetime.timedelta(hours=1)
+        },
+        app.config['SECRET_KEY'],
+        algorithm='HS256'
+    )
     return jsonify({'token': token})
 
 @app.route('/logout', methods=['POST'])
+@login_required
 def logout():
-    token = request.headers.get('Authorization')
-    if not token:
-        return jsonify({'error': 'missing token'}), 401
-    key = SecretKey.query.filter_by(key=token).first()
-    if key:
-        db.session.delete(key)
-        db.session.commit()
+    # With JWTs there is no server-side session to invalidate
     return jsonify({'message': 'logged out'})
 
 @app.route('/secret', methods=['POST'])
+@login_required
 def create_secret():
-    token = request.headers.get('Authorization')
-    key = SecretKey.query.filter_by(key=token).first()
-    if not key:
-        return jsonify({'error': 'invalid token'}), 401
-    new_key = SecretKey(key=secrets.token_hex(16), user_id=key.user_id)
-    db.session.add(new_key)
-    db.session.commit()
-    return jsonify({'secret_key': new_key.key})
+    new_key = secrets.token_hex(16)
+    mongo_db.secret_keys.insert_one({'key': new_key, 'user_id': ObjectId(request.user_id)})
+    return jsonify({'secret_key': new_key})
 
 @app.route('/deposit', methods=['POST'])
+@login_required
 def deposit():
-    token = request.headers.get('Authorization')
-    key = SecretKey.query.filter_by(key=token).first()
-    if not key:
-        return jsonify({'error': 'invalid token'}), 401
     data = request.json
     amount = data.get('amount')
     # Here we would use Stripe to handle payment intent; omitted for brevity
-    user = User.query.get(key.user_id)
-    user.wallet += amount
-    db.session.commit()
-    return jsonify({'wallet': user.wallet})
+    user_id = ObjectId(request.user_id)
+    mongo_db.users.update_one({'_id': user_id}, {'$inc': {'wallet': amount}})
+    user = mongo_db.users.find_one({'_id': user_id})
+    return jsonify({'wallet': user['wallet']})
 
 @app.route('/generate', methods=['POST'])
+@login_required
 def generate():
-    token = request.headers.get('Authorization')
-    key = SecretKey.query.filter_by(key=token).first()
-    if not key:
-        return jsonify({'error': 'invalid token'}), 401
     data = request.json
     prompt = data.get('prompt')
     if not prompt:
         return jsonify({'error': 'missing prompt'}), 400
-    user = User.query.get(key.user_id)
-    if user.wallet <= 0:
+    user = mongo_db.users.find_one({'_id': ObjectId(request.user_id)})
+    if user['wallet'] <= 0:
         return jsonify({'error': 'insufficient funds'}), 402
     openai.api_key = app.config['OPENAI_API_KEY']
     # Proxy settings could be configured via environment variables
@@ -121,26 +118,32 @@ def generate():
     usage = response['usage']
     cost = usage['total_tokens'] * 0.01  # Example price
     total = cost * app.config['OPENAI_PRICE_MULTIPLIER']
-    user.wallet -= total
-    db.session.add(Usage(user_id=user.id, prompt_tokens=usage['prompt_tokens'], completion_tokens=usage['completion_tokens'], cost=total))
-    db.session.commit()
+    mongo_db.users.update_one({'_id': ObjectId(request.user_id)}, {'$inc': {'wallet': -total}})
+    mongo_db.usage.insert_one({
+        'user_id': ObjectId(request.user_id),
+        'prompt_tokens': usage['prompt_tokens'],
+        'completion_tokens': usage['completion_tokens'],
+        'cost': total
+    })
+    user = mongo_db.users.find_one({'_id': ObjectId(request.user_id)})
     return jsonify({
         'response': response['choices'][0]['text'],
         'usage': usage,
         'cost_charged': total,
-        'wallet_balance': user.wallet
+        'wallet_balance': user['wallet']
     })
 
 @app.route('/usage', methods=['GET'])
+@login_required
 def get_usage():
-    token = request.headers.get('Authorization')
-    key = SecretKey.query.filter_by(key=token).first()
-    if not key:
-        return jsonify({'error': 'invalid token'}), 401
-    usages = Usage.query.filter_by(user_id=key.user_id).all()
+    usages = mongo_db.usage.find({'user_id': ObjectId(request.user_id)})
     result = []
     for u in usages:
-        result.append({'prompt_tokens': u.prompt_tokens, 'completion_tokens': u.completion_tokens, 'cost': u.cost})
+        result.append({
+            'prompt_tokens': u['prompt_tokens'],
+            'completion_tokens': u['completion_tokens'],
+            'cost': u['cost']
+        })
     return jsonify({'usage': result})
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- switch backend from SQLite/SQLAlchemy to MongoDB using PyMongo
- implement JWT session tokens with helper decorator
- update endpoints to use MongoDB and JWT
- document new setup steps and features
- update requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685649856ef48328a5a3362388d34d22